### PR TITLE
Only Reformat Contents of Output Directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ let package = Package(
     ...
     dependencies: [
         ...
-        .package(url: "https://github.com/john-mueller/TidyHTMLPublishStep", from: "0.1.0")
+        .package(url: "https://github.com/mgacy/TidyHTMLPublishStep", from: "0.1.1")
     ],
     targets: [
         .target(
             ...
             dependencies: [
                 ...
-                "TidyHTMLPublishStep"
+                .product(name: "TidyHTMLPublishStep", package: "tidyhtmlpublishstep")
             ]
         )
     ]

--- a/Sources/TidyHTMLPublishStep/TidyHTMLPublishStep.swift
+++ b/Sources/TidyHTMLPublishStep/TidyHTMLPublishStep.swift
@@ -16,11 +16,8 @@ extension PublishingStep {
     public static func tidyHTML(indentedBy indentation: Indentation.Kind? = nil) -> Self {
         .step(named: "Tidy HTML") { context in
             do {
-                let root = try context.folder(at: "")
-
-                let files = root.files.recursive
-
-                for file in files where file.extension == "html" {
+                let outputFolder = try context.outputFolder(at: "")
+                for file in outputFolder.files.recursive where file.extension == "html" {
                     let html = try file.readAsString()
 
                     let outputSettings = OutputSettings()


### PR DESCRIPTION
Only tidy HTML files in the publishing context's output folder rather every HTML file in the package directory. Also update the README.